### PR TITLE
User interface improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Project: STM8_serial_flasher
 
 CC            = gcc
-CFLAGS        = -c -Wall -I./STM8_Routines
+CFLAGS        = -c -Wall -pedantic -I./STM8_Routines
 LDFLAGS       = -g3 -lm
 SOURCES       = bootloader.c hexfile.c main.c misc.c serial_comm.c
 INCLUDES      = globals.h misc.h bootloader.h hexfile.h serial_comm.h main.h

--- a/globals.h
+++ b/globals.h
@@ -19,6 +19,7 @@
 
 // include files
 #include <stdint.h>
+#include <stdbool.h>
 #include <inttypes.h>
 
 
@@ -45,6 +46,8 @@ global uint8_t        g_pauseOnExit;
 /// bootloader UART mode and interface: 0=duplex, 1=1-wire reply, 2=2-wire reply
 global uint8_t        g_UARTmode;
 
+// Verbose console output
+global bool verbose;
 
 // undefine global again
 #undef global

--- a/main.c
+++ b/main.c
@@ -369,9 +369,9 @@ int main(int argc, char ** argv) {
 
     // convert to memory image, depending on file type
     const char *dot = strrchr (hexfile, '.');
-    if (dot && strstr(dot, ".s19"))                                                  // Motorola S-record format
+    if (dot && !strcmp(dot, ".s19"))                                                  // Motorola S-record format
       convert_s19(buf, &imageStart, &numBytes, image);
-    else if (dot && (strstr(dot, ".hex") || strstr(dot, ".ihx")))  // Intel HEX-format
+    else if (dot && (!strcmp(dot, ".hex") || !strcmp(dot, ".ihx")))  // Intel HEX-format
       convert_hex(buf, &imageStart, &numBytes, image);
     else {
       setConsoleColor(PRM_COLOR_RED);

--- a/main.c
+++ b/main.c
@@ -366,11 +366,12 @@ int main(int argc, char ** argv) {
     
     // import hexfile
     load_hexfile(hexfile, buf, BUFSIZE);
-    
+
     // convert to memory image, depending on file type
-    if (strstr(hexfile, ".s19") != NULL)                                              // Motorola S-record format
+    const char *dot = strrchr (hexfile, '.');
+    if (dot && strstr(dot, ".s19"))                                                  // Motorola S-record format
       convert_s19(buf, &imageStart, &numBytes, image);
-    else if ((strstr(hexfile, ".hex") != NULL) || (strstr(hexfile, ".ihx") != NULL))  // Intel HEX-format
+    else if (dot && (strstr(dot, ".hex") || strstr(dot, ".ihx")))  // Intel HEX-format
       convert_hex(buf, &imageStart, &numBytes, image);
     else {
       setConsoleColor(PRM_COLOR_RED);


### PR DESCRIPTION
- Fixed the detection of file extensions (previously, e.g. file.s1982test.ihx would be considered a Motorola S-Record file instead of Intel hex).
- Read input file early, to be able to report file errors early.
- Add -v flag for verbose output.

Philipp

P.S.: Warning: Not tested on STM8 hardware yet.
